### PR TITLE
Fix a double slash in crates.io URL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ extern crate serde_derive;
 use std::fmt;
 use std::process;
 
-static DEFAULT: &'static str = "https://crates.io/";
+static DEFAULT: &'static str = "https://crates.io";
 
 static USAGE: &'static str = r"
 Usage:


### PR DESCRIPTION
Fixes #102